### PR TITLE
Tweak mobile menu title and header font weights

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
 
 body {
     font-family: Inter;

--- a/mobile/header.html
+++ b/mobile/header.html
@@ -193,11 +193,9 @@
         title
       ))))]
 
-      const pageTitle = document.title.replace("- Discourse", "").trim();
-
       const returnHtml = [ h("a.close-icon",  [h("img", {
         src: "https://raw.githubusercontent.com/hashdeps/discourse-brand-header/main/assets/close.svg"
-      }),  h("b", pageTitle)])];
+      }),  h("b", "HASH")])];
 
       if(!user) {
         returnHtml.push(signUpLinks)


### PR DESCRIPTION
A couple of visual tweaks:
1. The page title is too long for the mobile menu. I've added a shorter one.
2. The main header links should be `font-weight: 600`, but we weren't loading that weight. I've added it.